### PR TITLE
Fix import of SPECIAL_FIELD_NAMES

### DIFF
--- a/src/oemof_tabular_plugins/datapackage/building.py
+++ b/src/oemof_tabular_plugins/datapackage/building.py
@@ -1,14 +1,12 @@
 import os
 import warnings
 import pandas as pd
-from oemof.tabular.config import config
 from oemof.tabular.datapackage import building
 from datapackage import Package
 
-SPECIAL_FIELD_NAMES = {}
-for fk, descriptor in config.FOREIGN_KEY_DESCRIPTORS.items():
-    for el in descriptor:
-        SPECIAL_FIELD_NAMES[el["fields"]] = fk
+# TODO when oemof.tabular is updated with inferred metadata PR, use
+# from oemof.tabular.config import config
+import oemof_tabular_plugins.datapackage.config as config
 
 
 def map_sequence_profiles_to_resource_name(p, excluded_profiles=("timeindex",)):

--- a/src/oemof_tabular_plugins/datapackage/config.py
+++ b/src/oemof_tabular_plugins/datapackage/config.py
@@ -1,0 +1,6 @@
+from oemof.tabular.config import config
+
+SPECIAL_FIELD_NAMES = {}
+for fk, descriptor in config.FOREIGN_KEY_DESCRIPTORS.items():
+    for el in descriptor:
+        SPECIAL_FIELD_NAMES[el["fields"]] = fk


### PR DESCRIPTION
## Summary of the discussion
The import of SPECIAL_FIELD_NAMES was made from oemof.tabular, however this variable does not exists there yet (this is in a PR on oemof.tabular repo)

When the oemof.tabular PR is merged, then one just need to delete `config.py` (if not used for any other purpose) and modify the import statement in `building.py` (marked with a TODO in comment)
