### PR TITLE
Add checks when building datapackage.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - simple usecases testing with datapackages as inputs
 - Facade SimpleCrop in wefe subpackage to simulate a crop growth without accounting for water in (following this reference https://doi.org/10.1016/j.eja.2019.01.009), a test model is provided in `examples/scenarios/test_crop`.
 - Possibility to vizualize results in dash app without having to rerun the simulation, thanks to `script/compute.py::display_scenario_results`. To use this feature, one needs to have previously saved the simulation results as raw oemof file. This is automatically done when running `script/compute.py::compute_scenario`. To disable this feature, set the `save_raw_results` argument to `False` in the latter function. A convenience script is available under `examples/scripts/results.py`
+- Check that values of foreign keys to resources in data/sequences have a match in target sequence headers and inform the user if it not the case with a comprehensive error message.
+- Raises a comprehensive error when inferring foreign keys of a resource, if this resource raises a `CastError` (for example values separated with "," instead of ";")
 
 ### Changed
 - structure of the general package and the wefe package

--- a/src/oemof_tabular_plugins/datapackage/building.py
+++ b/src/oemof_tabular_plugins/datapackage/building.py
@@ -118,8 +118,9 @@ def infer_resource_foreign_keys(resource, sequences_profiles_to_resource, busses
                     possible_field_values = [
                         f"'{seq}'" for seq in sequences_profiles_to_resource
                     ]
-                    logging.warning(
+                    logging.error(
                         f"The value '{potential_fk}' of the field '{field.name}' of the resource '{r.name}' does not match the headers of any sequences. "
+                        "If this field is not meant to be a foreign key, you can safely ignore this error :) "
                         f"If this field is meant to be a foreign key to a sequence, then possible values are: {','.join(possible_field_values)}"
                     )
 

--- a/src/oemof_tabular_plugins/datapackage/building.py
+++ b/src/oemof_tabular_plugins/datapackage/building.py
@@ -2,6 +2,7 @@ import os
 import warnings
 import logging
 import pandas as pd
+from tableschema.exceptions import CastError
 from oemof.tabular.datapackage import building
 from datapackage import Package
 
@@ -79,7 +80,12 @@ def infer_resource_foreign_keys(resource, sequences_profiles_to_resource, busses
 
     """
     r = resource
-    data = pd.DataFrame.from_records(r.read(keyed=True))
+    try:
+        data = pd.DataFrame.from_records(r.read(keyed=True))
+    except CastError:
+        raise ValueError(
+            f"Error while parsing the resource '{r.descriptor.get('path', r.name)}'. Check that all lines in the file have same number of records. Sometimes it might also a ',' instead of ';' as separator or vice versa."
+        )
     # TODO not sure this should be set here
     r.descriptor["schema"]["primaryKey"] = "name"
     if "foreignKeys" not in r.descriptor["schema"]:

--- a/src/oemof_tabular_plugins/datapackage/building.py
+++ b/src/oemof_tabular_plugins/datapackage/building.py
@@ -121,6 +121,38 @@ def infer_resource_foreign_keys(resource, sequences_profiles_to_resource, busses
     return r
 
 
+def check_profiles(package):
+    """Check that values of foreign keys to resources in data/sequences have a match in target sequence headers
+    Parameters
+    ----------
+    package: datapackage instance
+    Returns
+    -------
+    None, raises an error if a value assigned under the foreign key field does not match target sequence headers
+
+    """
+    for r in package.resources:
+        fkeys = r.descriptor["schema"].get("foreignKeys", [])
+        if fkeys:
+
+            data = pd.DataFrame.from_records(r.read(keyed=True))
+            for foreign_key in fkeys:
+                fk_field = foreign_key["fields"]
+                fk_target = foreign_key["reference"]["resource"]
+                if fk_target != "bus":
+                    for fk_value in data[fk_field].dropna().unique():
+                        sequence_descriptor = package.get_resource(fk_target).descriptor
+                        sequence_headers = [
+                            f"{f['name']}"
+                            for f in sequence_descriptor["schema"].get("fields", [])
+                        ]
+                        if fk_value not in sequence_headers:
+                            raise ValueError(
+                                f"The value {fk_value} of the field {fk_field} within the resource {r.name} does not match the headers of its resource within '{sequence_descriptor['path']}'\n"
+                                f"possible values for the field {fk_field} are: {', '.join(sequence_headers)}"
+                            )
+
+
 def infer_package_foreign_keys(package, typemap=None):
     """Infer the foreign_keys from data/elements and data/sequences and update meta data
 
@@ -271,3 +303,4 @@ def infer_metadata_from_data(
     p.commit()
     p.save(os.path.join(path, metadata_filename))
     infer_busses_carrier(p)
+    check_profiles(p)


### PR DESCRIPTION
## Summary of the discussion

Add helpful checks and error messages when datapackage resources are not properly formated or have typo in foreign keys. The error message contain reference to resource name and in which file to find the resource.

## Type of change (CHANGELOG.md)

### Added
- Check that values of foreign keys to resources in data/sequences have a match in target sequence headers and inform the user if it not the case with a comprehensive error message.
- Raises a comprehensive error when inferring foreign keys of a resource, if this resource raises a `CastError` (for example values separated with "," instead of ";")
