### PR TITLE
Feature/prepare mimo release

### DIFF
--- a/requirements/build_requirements.txt
+++ b/requirements/build_requirements.txt
@@ -1,6 +1,6 @@
 # Right now this is a problem as oemof.tabular is not installable from releases because of requirements conflictspytho
 numpy==1.26.0
 oemof.tabular @ git+https://github.com/oemof/oemof-tabular.git@dev
-oemof-industry @ git+https://github.com/sedos-project/oemof.industry.git@saltwater
+oemof-industry==0.1.1rc2
 dash
 Werkzeug==2.2.2

--- a/src/oemof_tabular_plugins/wefe/facades/crops.py
+++ b/src/oemof_tabular_plugins/wefe/facades/crops.py
@@ -664,35 +664,35 @@ class MimoCrop(MIMO):
     Please remove them and try again.
     """
 
-    type: str
+    type: str = "mimo-crop"
 
-    name: str
+    name: str = ""
 
-    tech: str
+    tech: str = "mimo"
 
-    carrier: str
+    carrier: str = ""
 
-    primary: str
+    primary: str = ""
 
-    expandable: bool
+    expandable: bool = False
 
-    capacity: float
+    capacity: float = 0
 
-    capacity_minimum: float
+    capacity_minimum: float = None
 
-    capacity_potential: float
+    capacity_potential: float = None
 
-    capacity_cost: float
+    capacity_cost: float = 0
 
-    solar_energy_bus: Bus
+    solar_energy_bus: Bus = None
 
-    precipitation_bus: Bus
+    precipitation_bus: Bus = None
 
-    irrigation_bus: Bus
+    irrigation_bus: Bus = None
 
-    crop_bus: Bus
+    crop_bus: Bus = None
 
-    biomass_bus: Bus
+    biomass_bus: Bus = None
 
     time_profile: Union[float, Sequence[float]] = None
 


### PR DESCRIPTION
Make the fields of the MIMO be kwargs such that the inheritance rule of dataclass does not raise errors.

If default-arguments are placed before non-default arguments in the parent and child initialization it triggers an error, this is the easiest way to go around this problem.

