### PR TITLE
Feature/improve results page

### DIFF
--- a/src/oemof_tabular_plugins/general/post_processing/gui.py
+++ b/src/oemof_tabular_plugins/general/post_processing/gui.py
@@ -104,7 +104,7 @@ def encode_image_file(img_path):
     return encoded_img
 
 
-def sankey(results, display_name, date_time_index=None, ts=None):
+def sankey(results, display_name, units, date_time_index=None, ts=None):
     """
     Return a dict for a Plotly Sankey diagram, using df_results (MultiIndex).
     Optionally, select a single timestep `ts` for the flow values.
@@ -113,6 +113,7 @@ def sankey(results, display_name, date_time_index=None, ts=None):
     sources = []
     targets = []
     values = []
+    customdata = []
 
     # Extract all buses from df_results
     busses = results.index.get_level_values("bus").unique()
@@ -167,9 +168,14 @@ def sankey(results, display_name, date_time_index=None, ts=None):
             else:
                 flow_value = 0
 
+            # Get flow value unit
+            unit = units.get(carrier, "UNIT NOT FOUND")
+
+
             sources.append(labels.index(source_label))
             targets.append(labels.index(target_label))
             values.append(flow_value)
+            customdata.append(unit)
 
     # Build the Sankey figure
     fig = go.Figure(
@@ -187,9 +193,10 @@ def sankey(results, display_name, date_time_index=None, ts=None):
                     source=sources,
                     target=targets,
                     value=values,
+                    customdata=customdata,
                     hovertemplate=(
                         "Link from node %{source.label}<br />"
-                        + "to node %{target.label}<br />has value %{value}<extra></extra>"
+                        + "to node %{target.label}<br />has value %{value} %{customdata}<extra></extra>"
                     ),
                 ),
             )
@@ -461,7 +468,7 @@ def prepare_app(app, dp_path, results, tables, services, units=None):
                 options={k: v for k, v in enumerate(date_time_index)},
                 value=None,
             ),
-            dcc.Graph(id="sankey", figure=sankey(results, display_name, date_time_index)),
+            dcc.Graph(id="sankey", figure=sankey(results, display_name, units, date_time_index)),
         ]
         + [
             dcc.Graph(
@@ -470,7 +477,7 @@ def prepare_app(app, dp_path, results, tables, services, units=None):
             )
             for bus, fig in zip(busses, bus_figures)
         ]
-        + [dcc.Graph(id="sankey_aggregate", figure=sankey(results, display_name, date_time_index))]
+        + [dcc.Graph(id="sankey_aggregate", figure=sankey(results, display_name, units, date_time_index))]
         # + [
         #     html.H4(["Energy system"]),
         #     html.Img(
@@ -514,6 +521,13 @@ def prepare_app(app, dp_path, results, tables, services, units=None):
             for direction, asset, carrier, facade_type in bus_df.index:
                 row = bus_df.loc[(direction, asset, carrier, facade_type)]
 
+                # Add unit to bus plot tilte
+                unit = units.get(carrier, "UNIT NOT FOUND")
+
+                fig.update_layout(
+                    title=f"{display_name(bus)} bus node {unit}"
+                )
+
                 # Determine sign for plotting
                 negative_sign = -1 if direction == "in" else 1
                 asset_name = display_name(asset)
@@ -551,7 +565,7 @@ def prepare_app(app, dp_path, results, tables, services, units=None):
 
             bus_figures.append(fig)
 
-        return [sankey(results, display_name, date_time_index, ts)] + bus_figures
+        return [sankey(results, display_name, units, date_time_index, ts)] + bus_figures
 
     @app.callback(
         # The value of these components of the layout will be changed by this callback

--- a/src/oemof_tabular_plugins/general/post_processing/gui.py
+++ b/src/oemof_tabular_plugins/general/post_processing/gui.py
@@ -262,6 +262,9 @@ def prepare_app(app, dp_path, results, tables, services, units=None, label_map=N
 
     # Only plot busses that a) have the parameter "plot" == True and b) are in the results
     bus_data = pd.DataFrame.from_records(p0.get_resource("bus").read(keyed=True))
+    if "plot" not in bus_data.columns:
+        bus_data["plot"] = True
+
     available_busses = set(results.index.get_level_values("bus"))
 
     busses = bus_data.loc[

--- a/src/oemof_tabular_plugins/general/post_processing/gui.py
+++ b/src/oemof_tabular_plugins/general/post_processing/gui.py
@@ -109,6 +109,7 @@ def sankey(results, display_name, units, date_time_index=None, ts=None):
     Return a dict for a Plotly Sankey diagram, using df_results (MultiIndex).
     Optionally, select a single timestep `ts` for the flow values.
     """
+    node_ids = []
     labels = []
     sources = []
     targets = []
@@ -138,18 +139,25 @@ def sankey(results, display_name, units, date_time_index=None, ts=None):
             # direction == "out" → flow FROM asset TO bus
 
             if direction == "in":
-                source_label = display_name(bus)
-                target_label = display_name(asset)
+                source_id = bus
+                target_id = asset
             elif direction == "out":
-                source_label = display_name(asset)
-                target_label = display_name(bus)
+                source_id = asset
+                target_id = bus
             else:
                 continue
 
-            # Add labels if not already present
-            for lbl in (source_label, target_label):
-                if lbl not in labels:
-                    labels.append(lbl)
+            source_label = display_name(source_id)
+            target_label = display_name(target_id)
+
+            # Add nodes if not already present
+            for node_id, node_label in (
+                (source_id, source_label),
+                (target_id, target_label),
+            ):
+                if node_id not in node_ids:
+                    node_ids.append(node_id)
+                    labels.append(node_label)
 
             # Get flow value
             if date_time_index is not None:
@@ -171,9 +179,8 @@ def sankey(results, display_name, units, date_time_index=None, ts=None):
             # Get flow value unit
             unit = units.get(carrier, "UNIT NOT FOUND")
 
-
-            sources.append(labels.index(source_label))
-            targets.append(labels.index(target_label))
+            sources.append(node_ids.index(source_id))
+            targets.append(node_ids.index(target_id))
             values.append(flow_value)
             customdata.append(unit)
 
@@ -196,7 +203,8 @@ def sankey(results, display_name, units, date_time_index=None, ts=None):
                     customdata=customdata,
                     hovertemplate=(
                         "Link from node %{source.label}<br />"
-                        + "to node %{target.label}<br />has value %{value} %{customdata}<extra></extra>"
+                        + "to node %{target.label}<br />"
+                        + "has value %{value} %{customdata}<extra></extra>"
                     ),
                 ),
             )

--- a/src/oemof_tabular_plugins/general/post_processing/gui.py
+++ b/src/oemof_tabular_plugins/general/post_processing/gui.py
@@ -222,12 +222,13 @@ def sankey(results, display_name, units, date_time_index=None, ts=None):
 
 
 
-def prepare_app(app, dp_path, results, tables, services, units=None):
+def prepare_app(app, dp_path, results, tables, services, units=None, label_map=None):
     """ """
     p0 = Package(dp_path)
 
     # Dynamic label mapping to use verbose names (if available)
-    label_map = {}
+    if label_map is None:
+        label_map = {}
 
     for resource_name in p0.resource_names:
         try:
@@ -320,6 +321,8 @@ def prepare_app(app, dp_path, results, tables, services, units=None):
 
         if "Component name" in df.columns:
             df["Component name"] = df["Component name"].apply(display_name)
+        elif "kpi" in df.columns:
+            df["kpi"] = df["kpi"].apply(display_name)
         tables_figure.append(
             html.Div(
                 style=table__item_style[table],

--- a/src/oemof_tabular_plugins/general/post_processing/gui.py
+++ b/src/oemof_tabular_plugins/general/post_processing/gui.py
@@ -261,8 +261,6 @@ def prepare_app(app, dp_path, results, tables, services, units=None):
         "name",
     ].tolist()
 
-    import pdb; pdb.set_trace()
-
     for bus in busses:
         fig = go.Figure(layout=dict(title=f"{display_name(bus)} bus node"))
 
@@ -603,5 +601,3 @@ def prepare_app(app, dp_path, results, tables, services, units=None):
         return answer
 
     return app
-
-    # import ipdb;ipdb.set_trace()

--- a/src/oemof_tabular_plugins/general/post_processing/gui.py
+++ b/src/oemof_tabular_plugins/general/post_processing/gui.py
@@ -214,32 +214,33 @@ def prepare_app(app, dp_path, results, tables, services, units=None):
     # List for bus figures
     bus_figures = []
 
-    p0 = Package(dp_path)
+    # Only plot busses that a) have the parameter "plot" == True and b) are in the results
     bus_data = pd.DataFrame.from_records(p0.get_resource("bus").read(keyed=True))
-    busses = bus_data.name.tolist()
+    available_busses = set(results.index.get_level_values("bus"))
+
+    busses = bus_data.loc[
+        bus_data["plot"].fillna(False)
+        & bus_data["name"].isin(available_busses),
+        "name",
+    ].tolist()
+
+    import pdb; pdb.set_trace()
 
     for bus in busses:
         fig = go.Figure(layout=dict(title=f"{bus} bus node"))
 
-        # Extract flows for this bus directly from df_results
-        bus_df = results.loc[bus] if bus in results.index.get_level_values("bus") else None
+        bus_df = results.loc[bus]
+        for (direction, asset, carrier, facade_type), row in bus_df.iterrows():
+            flow_values = row[date_time_index].values
 
-        if bus_df is not None and not bus_df.empty:
-            for (direction, asset, carrier, facade_type), row in bus_df.iterrows():
-                flow_values = row[date_time_index].values
+            sign = 1 if direction == "out" else -1
 
-                sign = 1 if direction == "out" else -1
-
-                fig.add_trace(
-                    go.Scatter(
-                        x=date_time_index,
-                        y=flow_values * sign,
-                        name=asset,
-                    )
+            fig.add_trace(
+                go.Scatter(
+                    x=date_time_index,
+                    y=flow_values * sign,
+                    name=asset,
                 )
-        else:
-            logging.error(
-                f"No flow was recorded through the bus '{bus}'. This is likely due to an error in the input files."
             )
 
         # else:

--- a/src/oemof_tabular_plugins/general/post_processing/gui.py
+++ b/src/oemof_tabular_plugins/general/post_processing/gui.py
@@ -203,7 +203,13 @@ def sankey(results, display_name, units, date_time_index=None, ts=None):
         ]
     )
 
-    fig.update_layout(title_text="Basic Sankey Diagram", font_size=10)
+    # Dynamic title
+    if ts is None:
+        sankey_title = "Full Year Sankey Diagram"
+    else:
+        sankey_title = f"Sankey Diagram at Timestep {ts}"
+
+    fig.update_layout(title_text=sankey_title, font_size=10)
     return fig.to_dict()
 
 

--- a/src/oemof_tabular_plugins/general/post_processing/gui.py
+++ b/src/oemof_tabular_plugins/general/post_processing/gui.py
@@ -104,7 +104,7 @@ def encode_image_file(img_path):
     return encoded_img
 
 
-def sankey(results, date_time_index=None, ts=None):
+def sankey(results, display_name, date_time_index=None, ts=None):
     """
     Return a dict for a Plotly Sankey diagram, using df_results (MultiIndex).
     Optionally, select a single timestep `ts` for the flow values.
@@ -137,11 +137,11 @@ def sankey(results, date_time_index=None, ts=None):
             # direction == "out" → flow FROM asset TO bus
 
             if direction == "in":
-                source_label = bus
-                target_label = asset
+                source_label = display_name(bus)
+                target_label = display_name(asset)
             elif direction == "out":
-                source_label = asset
-                target_label = bus
+                source_label = display_name(asset)
+                target_label = display_name(bus)
             else:
                 continue
 
@@ -203,6 +203,30 @@ def sankey(results, date_time_index=None, ts=None):
 
 def prepare_app(app, dp_path, results, tables, services, units=None):
     """ """
+    p0 = Package(dp_path)
+
+    # Dynamic label mapping to use verbose names (if available)
+    label_map = {}
+
+    for resource_name in p0.resource_names:
+        try:
+            df = pd.DataFrame.from_records(p0.get_resource(resource_name).read(keyed=True))
+
+            if "name" in df.columns and "verbose_name" in df.columns:
+                label_map.update(
+                    {
+                        row["name"]: row["verbose_name"]
+                        for _, row in df.iterrows()
+                        if pd.notna(row["verbose_name"])
+                    }
+                )
+
+        except Exception:
+            pass
+
+    def display_name(name):
+        return label_map.get(name, name)
+
     # Derive datetime index from results
     time_cols = [
         c for c in results.columns
@@ -227,7 +251,7 @@ def prepare_app(app, dp_path, results, tables, services, units=None):
     import pdb; pdb.set_trace()
 
     for bus in busses:
-        fig = go.Figure(layout=dict(title=f"{bus} bus node"))
+        fig = go.Figure(layout=dict(title=f"{display_name(bus)} bus node"))
 
         bus_df = results.loc[bus]
         for (direction, asset, carrier, facade_type), row in bus_df.iterrows():
@@ -239,7 +263,7 @@ def prepare_app(app, dp_path, results, tables, services, units=None):
                 go.Scatter(
                     x=date_time_index,
                     y=flow_values * sign,
-                    name=asset,
+                    name=display_name(asset),
                 )
             )
 
@@ -275,6 +299,7 @@ def prepare_app(app, dp_path, results, tables, services, units=None):
 
             df["unit"] = df[df.columns[0]].apply(set_value, args=(units,))
 
+        df["Component name"] = df["Component name"].apply(display_name)
         tables_figure.append(
             html.Div(
                 style=table__item_style[table],
@@ -339,6 +364,7 @@ def prepare_app(app, dp_path, results, tables, services, units=None):
                 if excess[unit].sum() > 0:
                     table_headers.append("Excess")
 
+        df["Component name"] = df["Component name"].apply(display_name)
         services_figure.append(
             html.Div(
                 id=f"{service}-service-div",
@@ -433,7 +459,7 @@ def prepare_app(app, dp_path, results, tables, services, units=None):
                 options={k: v for k, v in enumerate(date_time_index)},
                 value=None,
             ),
-            dcc.Graph(id="sankey", figure=sankey(results, date_time_index)),
+            dcc.Graph(id="sankey", figure=sankey(results, display_name, date_time_index)),
         ]
         + [
             dcc.Graph(
@@ -442,7 +468,7 @@ def prepare_app(app, dp_path, results, tables, services, units=None):
             )
             for bus, fig in zip(busses, bus_figures)
         ]
-        + [dcc.Graph(id="sankey_aggregate", figure=sankey(results, date_time_index))]
+        + [dcc.Graph(id="sankey_aggregate", figure=sankey(results, display_name, date_time_index))]
         # + [
         #     html.H4(["Energy system"]),
         #     html.Img(
@@ -474,7 +500,7 @@ def prepare_app(app, dp_path, results, tables, services, units=None):
         bus_figures = []
 
         for bus in busses:
-            fig = go.Figure(layout=dict(title=f"{bus} bus node"))
+            fig = go.Figure(layout=dict(title=f"{display_name(bus)} bus node"))
             max_y = 0
 
             # Skip if bus not in results
@@ -494,7 +520,7 @@ def prepare_app(app, dp_path, results, tables, services, units=None):
 
                 # Determine sign for plotting
                 negative_sign = -1 if direction == "in" else 1
-                asset_name = asset
+                asset_name = display_name(asset)
                 if asset == "battery":
                     asset_name += " discharge" if direction == "out" else " charge"
 
@@ -529,7 +555,7 @@ def prepare_app(app, dp_path, results, tables, services, units=None):
 
             bus_figures.append(fig)
 
-        return [sankey(results, date_time_index, ts)] + bus_figures
+        return [sankey(results, display_name, date_time_index, ts)] + bus_figures
 
     @app.callback(
         # The value of these components of the layout will be changed by this callback

--- a/src/oemof_tabular_plugins/general/post_processing/gui.py
+++ b/src/oemof_tabular_plugins/general/post_processing/gui.py
@@ -299,7 +299,8 @@ def prepare_app(app, dp_path, results, tables, services, units=None):
 
             df["unit"] = df[df.columns[0]].apply(set_value, args=(units,))
 
-        df["Component name"] = df["Component name"].apply(display_name)
+        if "Component name" in df.columns:
+            df["Component name"] = df["Component name"].apply(display_name)
         tables_figure.append(
             html.Div(
                 style=table__item_style[table],
@@ -364,7 +365,8 @@ def prepare_app(app, dp_path, results, tables, services, units=None):
                 if excess[unit].sum() > 0:
                     table_headers.append("Excess")
 
-        df["Component name"] = df["Component name"].apply(display_name)
+        if "Component name" in df.columns:
+            df["Component name"] = df["Component name"].apply(display_name)
         services_figure.append(
             html.Div(
                 id=f"{service}-service-div",

--- a/src/oemof_tabular_plugins/general/post_processing/gui.py
+++ b/src/oemof_tabular_plugins/general/post_processing/gui.py
@@ -505,14 +505,8 @@ def prepare_app(app, dp_path, results, tables, services, units=None):
             fig = go.Figure(layout=dict(title=f"{display_name(bus)} bus node"))
             max_y = 0
 
-            # Skip if bus not in results
-            if bus not in results.index.get_level_values("bus"):
-                logging.warning(f"Bus '{bus}' not found in results.")
-                bus_figures.append(fig)
-                continue
-
             bus_df = results.loc[bus]
-            if bus_df is None or bus_df.empty:
+            if bus_df.empty:
                 logging.warning(f"No flows found for bus '{bus}'.")
                 bus_figures.append(fig)
                 continue

--- a/src/oemof_tabular_plugins/general/post_processing/gui.py
+++ b/src/oemof_tabular_plugins/general/post_processing/gui.py
@@ -264,7 +264,7 @@ def prepare_app(app, dp_path, results, tables, services, units=None):
     available_busses = set(results.index.get_level_values("bus"))
 
     busses = bus_data.loc[
-        bus_data["plot"].fillna(False)
+        bus_data["plot"].fillna(True)   # default: plot == True if missing
         & bus_data["name"].isin(available_busses),
         "name",
     ].tolist()

--- a/src/oemof_tabular_plugins/general/post_processing/gui.py
+++ b/src/oemof_tabular_plugins/general/post_processing/gui.py
@@ -517,7 +517,7 @@ def prepare_app(app, dp_path, results, tables, services, units=None):
                 # Determine sign for plotting
                 negative_sign = -1 if direction == "in" else 1
                 asset_name = display_name(asset)
-                if asset == "battery":
+                if facade_type == "storage":
                     asset_name += " discharge" if direction == "out" else " charge"
 
                 # Safe time series extraction

--- a/src/oemof_tabular_plugins/general/post_processing/post_processing.py
+++ b/src/oemof_tabular_plugins/general/post_processing/post_processing.py
@@ -253,9 +253,14 @@ def post_processing(
             "total_water_footprint": "[m³]",
             "system_opex_total": "[USD/a]",
             "total_variable_cost_moo": "[USD/a]",
-            # service units
+            # service (carrier) units
             "electricity": "[kWh]",
-            "water": "[m³]"
+            "water": "[m³]",
+            "energy": "[kWh]",
+            "biogas": "[kWh]",
+            "diesel": "[kWh]",
+            "fuel": "[kWh]",
+            "biomass": "[kg]"
         }
 
     if calculations is None:

--- a/src/oemof_tabular_plugins/general/post_processing/post_processing.py
+++ b/src/oemof_tabular_plugins/general/post_processing/post_processing.py
@@ -208,6 +208,7 @@ def post_processing(
     if parameters_units is None:
         #  Units of Capacities and Kpis in Results
         parameters_units = {
+            # capacities units: only used if not generated from CAPACITIES_UNIT
             "drinking-water-storage": "[m³]",
             "rainwater-harvesting": "[m²]",
             "service-water-storage": "[m³]",
@@ -236,6 +237,7 @@ def post_processing(
             "pv-panel": "[kW]",
             "water-storage": "[m³]",
             "mimo": "[m³/h]",
+            # kpi units
             "annuity_total": "[USD/a]",
             "variable_costs_total": "[USD/a]",
             "ghg_emission_total": "[kgCO2e/a]",
@@ -244,11 +246,16 @@ def post_processing(
             "total_upfront_investments": "[USD]",
             "land_requirement_total": "[m²]",
             "total_water_consumption": "[m³/a]",
+            "total_indirect_water_consumption": "[m³/a]",
+            "water_scarcity_footprint": "[m³/a]",
             "total_annual_cost_moo": "[USD/a]",
             "ghg_emissions_total": "[kgCO2e/a]",
             "total_water_footprint": "[m³]",
             "system_opex_total": "[USD/a]",
             "total_variable_cost_moo": "[USD/a]",
+            # service units
+            "electricity": "[kWh]",
+            "water": "[m³]"
         }
 
     if calculations is None:

--- a/src/oemof_tabular_plugins/general/post_processing/post_processing.py
+++ b/src/oemof_tabular_plugins/general/post_processing/post_processing.py
@@ -267,6 +267,9 @@ def post_processing(
     if verbose_names is None:
         # KPI verbose names, component verbose names will be added later
         verbose_names = {
+            "annuity_total": "Total Annual Cost",
+            "total_annual_cost_moo": "Total Annual Cost",
+            "variable_costs_total": "Total Variable OPEX",
             "total_variable_cost_moo": "Total Variable OPEX",
             "total_upfront_investments": "Total Upfront Investment",
             "land_requirement_additional": "Additional Land Requirement",

--- a/src/oemof_tabular_plugins/general/post_processing/post_processing.py
+++ b/src/oemof_tabular_plugins/general/post_processing/post_processing.py
@@ -189,6 +189,7 @@ def post_processing(
     dp_path,
     dash_app=False,
     parameters_units=None,
+    verbose_names=None,
     infer_bus_carrier=True,
     calculations=None,
     kpi_calculations=None,
@@ -261,6 +262,20 @@ def post_processing(
             "diesel": "[kWh]",
             "fuel": "[kWh]",
             "biomass": "[kg]"
+        }
+
+    if verbose_names is None:
+        # KPI verbose names, component verbose names will be added later
+        verbose_names = {
+            "total_variable_cost_moo": "Total Variable OPEX",
+            "total_upfront_investments": "Total Upfront Investment",
+            "land_requirement_additional": "Additional Land Requirement",
+            "land_requirement_total": "Total Land Requirement",
+            "total_water_consumption": "Total Water Consumption",
+            "total_indirect_water_consumption": "Total Indirect Water Consumption",
+            "water_scarcity_footprint": "Water Scarcity Footprint",
+            "ghg_emissions_total": "Total GHG Emissions",
+            "system_opex_total": "Total System OPEX",
         }
 
     if calculations is None:
@@ -418,6 +433,7 @@ def post_processing(
             tables=result_tables,
             services=service_tables,
             units=parameters_units,
+            label_map=verbose_names
         )
         app.run(debug=False, port=8060)
 
@@ -426,7 +442,8 @@ def post_processing(
         calculator.dash_tables = {
             "result_tables": result_tables,
             "service_tables": service_tables,
-            "parameters_units": parameters_units
+            "parameters_units": parameters_units,
+            "verbose_names": verbose_names
         }
 
     # ----- OLD POST-PROCESSING - TO BE DELETED ONCE CERTAIN -----


### PR DESCRIPTION
units:
- add missing units to "parameters_units" in post_processing/post_processing
- add units to bus plots and sankey hovertemplate

bus plots:
- do not display empty bus plots
- add "plot" flag (default: True) as option to set to False and not plot certain busses (checkout WEFEgui component lib bus.csv)

verbose names:
- add kpi verbose names directly in post_processing, attach to server response 
- dynamically get component verbose names for all plots (capacities, services, busses, sankey) if available
- correct storage charge/discharge label for bus plots
- dynamic sankey titles